### PR TITLE
fix(table_pagination): added pagination padding, more consistent styling and controls

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/Pagination.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/Pagination.tsx
@@ -88,9 +88,29 @@ export default memo(
       currentPage,
       maxPageItemCount,
     );
+    const canGoPrevious = currentPage > 0;
+    const canGoNext = currentPage < pageCount - 1;
+
     return (
       <div ref={ref} className="dt-pagination" style={style}>
         <ul className="pagination pagination-sm">
+          <li className={!canGoPrevious ? 'disabled' : undefined}>
+            <a
+              href="#previous"
+              role="button"
+              onClick={e => {
+                e.preventDefault();
+                if (canGoPrevious) {
+                  onPageChange(currentPage - 1);
+                }
+              }}
+              aria-label="Previous page"
+              aria-disabled={!canGoPrevious}
+            >
+              «
+            </a>
+          </li>
+
           {pageItems.map(item =>
             typeof item === 'number' ? (
               // actual page number
@@ -115,6 +135,23 @@ export default memo(
               </li>
             ),
           )}
+
+          <li className={!canGoNext ? 'disabled' : undefined}>
+            <a
+              href="#next"
+              role="button"
+              onClick={e => {
+                e.preventDefault();
+                if (canGoNext) {
+                  onPageChange(currentPage + 1);
+                }
+              }}
+              aria-label="Next page"
+              aria-disabled={!canGoNext}
+            >
+              »
+            </a>
+          </li>
         </ul>
       </div>
     );

--- a/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
@@ -96,10 +96,68 @@ export default styled.div`
     .dt-pagination {
       text-align: right;
       /* use padding instead of margin so clientHeight can capture it */
-      padding-top: 0.5em;
+      padding: ${theme.gridUnit * 2}px ${theme.gridUnit * 2}px;
+      overflow: visible;
+      min-height: 48px;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
     }
     .dt-pagination .pagination {
       margin: 0;
+      display: flex;
+      align-items: center;
+      gap: ${theme.gridUnit}px;
+    }
+    .dt-pagination .pagination > li {
+      margin: 0;
+      list-style: none;
+    }
+    .dt-pagination .pagination > li > a,
+    .dt-pagination .pagination > li > span {
+      padding: ${theme.gridUnit}px ${theme.gridUnit * 2}px;
+      min-width: 28px;
+      height: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+      border-radius: ${theme.borderRadius}px;
+      background-color: transparent;
+      color: ${theme.colors.grayscale.dark1};
+      cursor: pointer;
+      transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+      text-decoration: none;
+      font-size: ${theme.typography.sizes.s}px;
+    }
+    .dt-pagination .pagination > li > a:hover,
+    .dt-pagination .pagination > li > span:hover {
+      color: ${theme.colors.primary.dark1};
+      background-color: ${theme.colors.grayscale.light5};
+    }
+    .dt-pagination .pagination > li.active > a,
+    .dt-pagination .pagination > li.active > a:hover {
+      background-color: ${theme.colors.primary.base};
+      border: 1px solid ${theme.colors.primary.base};
+      color: ${theme.colors.grayscale.light5};
+      cursor: default;
+    }
+    .dt-pagination .pagination > li.disabled > a,
+    .dt-pagination .pagination > li.disabled > a:hover {
+      cursor: not-allowed;
+      opacity: 1;
+      color: ${theme.colors.grayscale.dark1};
+      background-color: transparent;
+    }
+    .dt-pagination .pagination > li.dt-pagination-ellipsis > span {
+      border: none;
+      background: transparent;
+      cursor: default;
+    }
+    .dt-pagination .pagination > li.dt-pagination-ellipsis > span:hover {
+      border: none;
+      background: transparent;
+      color: ${theme.colors.grayscale.base};
     }
 
     .pagination > li > span.dt-pagination-ellipsis:focus,


### PR DESCRIPTION
### SUMMARY

The primary changes here include adding extra padding to the pagination buttons for tables.
Additionally, a UI change was made for the pagination buttons to better follow the current design of other pagination buttons (e.g. from the "Samples" section)

### BEFORE/AFTER SCREENSHOTS

BEFORE:
<img width="1915" height="411" alt="image" src="https://github.com/user-attachments/assets/15274700-97da-4419-93ab-25024a1adf73" />

AFTER:
<img width="1906" height="409" alt="image" src="https://github.com/user-attachments/assets/59c85025-6b73-4c2f-9c03-5a5e1eac7f81" />


### TESTING INSTRUCTIONS

While your data is visualized as a table chart, ensure the option of 'server pagination' is checked on. Then take a look at the padding and styling of the pagination buttons. Forward and back buttons should work when appropriate (if there is a page available forward and backwards).

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #4 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### SHOWCASE

https://github.com/user-attachments/assets/5f24ae48-e274-4810-b6b8-cff9372ceb02