### PR TITLE
feat(vizmodal): auto-focus text input on click

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -217,6 +217,27 @@ describe('VizTypeControl', () => {
     ).toBeInTheDocument();
   });
 
+  it('Auto-focuses search input when modal opens', async () => {
+    await waitForRenderWrapper();
+
+    const input = await screen.findByTestId(getTestId('search-input'));
+    await waitFor(() => expect(input).toHaveFocus());
+  });
+
+  it('Re-focuses search input on re-open', async () => {
+    await waitForRenderWrapper({ ...defaultProps, isModalOpenInit: false });
+
+    userEvent.click(screen.getByText('View all charts'));
+    const inputOpen = await screen.findByTestId(getTestId('search-input'));
+    await waitFor(() => expect(inputOpen).toHaveFocus());
+
+    userEvent.click(await screen.findByTestId('modal-cancel-button'));
+
+    userEvent.click(screen.getByText('View all charts'));
+    const inputReopen = await screen.findByTestId(getTestId('search-input'));
+    await waitFor(() => expect(inputReopen).toHaveFocus());
+  });
+
   it('Search visualization type', async () => {
     await waitForRenderWrapper();
 

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -54,6 +54,7 @@ interface VizTypeGalleryProps {
   selectedViz: string | null;
   className?: string;
   denyList: string[];
+  isOpen?: boolean;
 }
 
 type VizEntry = {
@@ -436,7 +437,7 @@ const doesVizMatchSelector = (viz: ChartMetadata, selector: string) =>
   (viz.tags || []).indexOf(selector) > -1;
 
 export default function VizTypeGallery(props: VizTypeGalleryProps) {
-  const { selectedViz, onChange, onDoubleClick, className, denyList } = props;
+  const { selectedViz, onChange, onDoubleClick, className, denyList, isOpen } = props;
   const { mountedPluginMetadata } = usePluginContext();
   const searchInputRef = useRef<HTMLInputElement>();
   const [searchInputValue, setSearchInputValue] = useState('');
@@ -584,6 +585,14 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
     setSearchInputValue('');
     searchInputRef.current!.blur();
   }, []);
+
+  useEffect(() => {
+    if (isOpen !== false) {
+      queueMicrotask(() => {
+        searchInputRef.current?.focus();
+      });
+    }
+  }, [isOpen]);
 
   const clickSelector = useCallback(
     (selector: string, sectionId: string) => {

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -137,6 +137,7 @@ const VizTypeControl = ({
           selectedViz={selectedViz}
           onChange={setSelectedViz}
           onDoubleClick={onSubmit}
+          isOpen={showModal}
           denyList={denyList}
         />
       </UnpaddedModal>


### PR DESCRIPTION
### SUMMARY

Added auto-focus for visualization modal by passing the modal’s open state to VizTypeGallery and focusing the input via a ref in a useEffect, plus tests to cover opening and reopening the modal.

### BEFORE/AFTER SCREENSHOTS

BEFORE:
<img width="1049" height="272" alt="image" src="https://github.com/user-attachments/assets/34c1a3fc-e0c1-462f-888c-5583045c9a1e" />

AFTER:
Similar to before except with the "Search all charts" search bar selected.

### TESTING INSTRUCTIONS

While on any chart, if you try to change the chart via the "View all charts" button and pull up the visualization modal, the search bar would not be focused and required the user to click prior to typing. Now, upon loading the visualization modal, the search bar is auto-focused meaning users are able to type right away, improving user experience.

### ADDITIONAL INFORMATION

- [x] Has associated issue: fixes #1 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### SHOWCASE

https://github.com/user-attachments/assets/08537d4c-7317-4a11-a90f-9b8c6a65b790