### PR TITLE
feat(table_chart):  hide 'Sort descending' when not applicable, button moved

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -328,6 +328,26 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort descending'),
+              default: true,
+              description: t(
+                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                isAggMode({ controls }) &&
+                Boolean(
+                  controls?.timeseries_limit_metric?.value &&
+                    !isEmpty(controls?.timeseries_limit_metric?.value),
+                ),
+              resetOnHide: false,
+            },
+          },
+        ],
+        [
+          {
             name: 'server_pagination',
             config: {
               type: 'CheckboxControl',
@@ -362,21 +382,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [
-          {
-            name: 'order_desc',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Sort descending'),
-              default: true,
-              description: t(
-                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
-              ),
-              visibility: isAggMode,
-              resetOnHide: false,
-            },
-          },
-        ],
+
         [
           {
             name: 'show_totals',


### PR DESCRIPTION
### SUMMARY

Made the "Sort descending" (order_desc) control only appear when a sort metric is selected (timeseries_limit_metric). Additionally, moved the order_desc control to sit directly below the "Sort query by" control for a more apparent connection between the two.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE:

<img width="310" height="254" alt="image" src="https://github.com/user-attachments/assets/60e8f41e-7cad-4eb1-b58b-8a4bed38a359" />


AFTER:

<img width="305" height="214" alt="image" src="https://github.com/user-attachments/assets/a369be82-2c0a-4f28-ad95-295aaf7e6780" />
<img width="311" height="134" alt="image" src="https://github.com/user-attachments/assets/4e9911c9-3ef6-4419-89e6-d7b6fdca061a" />


### TESTING INSTRUCTIONS

Begin by not seeing "Sort descending" control below "Sort query by". Then, choose a metric to sort the query by in the "Sort query by" control. This should lead you to seeing the "Sort descending" option to appear. From there, feel free to check or uncheck the descending option and see your data change order.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #10 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### SHOWCASE

https://github.com/user-attachments/assets/143d6bbf-b82c-4cb2-926b-cc1092cf420a
